### PR TITLE
Updated comment for Month/Year in .datetime()

### DIFF
--- a/ds3231.py
+++ b/ds3231.py
@@ -88,8 +88,8 @@ class DS3231:
             # 0x02 - Hour       0 12/24 AM/PM/20s BCD
             # 0x03 - WDay 1-7   0000 0 BCD
             # 0x04 - Day 1-31   00 BCD
-            # 0x05 - Month 0-12 Century 00 BCD
-            # 0x06 - Year 0-99  BCD
+            # 0x05 - Month 1-12 Century 00 BCD
+            # 0x06 - Year 0-99  BCD (2000-2099)
             seconds = bcdtodec(self._timebuf[0])
             minutes = bcdtodec(self._timebuf[1])
 


### PR DESCRIPTION
- The inline comment reported 0-12, while the allowing range is 1-12
- extended the comment for Year to emphasise that 0-99 stands for 2000-2099